### PR TITLE
Add Apple App Store compliance cleanup script

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -30,7 +30,16 @@ const withSquareXCodeProject = (config) => {
         const project = conf.modResults;
         project.addBuildPhase([], "PBXShellScriptBuildPhase", "Square Framework Run Script - InAppPaymentsSDK", project.getFirstTarget().uuid, {
             shellPath: "/bin/sh",
-            shellScript: 'FRAMEWORKS="${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}" && "${FRAMEWORKS}/SquareInAppPaymentsSDK.framework/setup"',
+            shellScript: `
+FRAMEWORKS="\${BUILT_PRODUCTS_DIR}/\${FRAMEWORKS_FOLDER_PATH}"
+# Run the setup script
+"\${FRAMEWORKS}/SquareInAppPaymentsSDK.framework/setup"
+# Clean up for App Store compliance
+rm -f "\${FRAMEWORKS}/SquareInAppPaymentsSDK.framework/setup"
+rm -rf "\${FRAMEWORKS}/SquareInAppPaymentsSDK.framework/Frameworks"
+rm -rf "\${FRAMEWORKS}/SquareBuyerVerificationSDK.framework/Frameworks"
+find "\${FRAMEWORKS}" -name "*.bundle" -type d -delete
+`,
         });
         return conf;
     });

--- a/plugin/src/index.ts
+++ b/plugin/src/index.ts
@@ -60,8 +60,16 @@ const withSquareXCodeProject: ConfigPlugin = (config) => {
       project.getFirstTarget().uuid,
       {
         shellPath: "/bin/sh",
-        shellScript:
-          'FRAMEWORKS="${BUILT_PRODUCTS_DIR}/${FRAMEWORKS_FOLDER_PATH}" && "${FRAMEWORKS}/SquareInAppPaymentsSDK.framework/setup"',
+        shellScript: `
+FRAMEWORKS="\${BUILT_PRODUCTS_DIR}/\${FRAMEWORKS_FOLDER_PATH}"
+# Run the setup script
+"\${FRAMEWORKS}/SquareInAppPaymentsSDK.framework/setup"
+# Clean up for App Store compliance
+rm -f "\${FRAMEWORKS}/SquareInAppPaymentsSDK.framework/setup"
+rm -rf "\${FRAMEWORKS}/SquareInAppPaymentsSDK.framework/Frameworks"
+rm -rf "\${FRAMEWORKS}/SquareBuyerVerificationSDK.framework/Frameworks"
+find "\${FRAMEWORKS}" -name "*.bundle" -type d -delete
+`,
       }
     );
 


### PR DESCRIPTION
- Remove nested Frameworks directories after setup script execution
- Delete unsigned setup file to prevent code signing validation errors
- Clean up bundle files that Apple App Store rejects
- Fixes App Store validation errors: 'Invalid Bundle' and 'Invalid Signature'
- Resolves nested bundles and disallowed files issues for iOS submissions

Tested successfully with app submission to Apple App Store.